### PR TITLE
Fix G++ compile error

### DIFF
--- a/src/eve-server/inventory/InventoryItem.cpp
+++ b/src/eve-server/inventory/InventoryItem.cpp
@@ -289,7 +289,7 @@ RefPtr<_Ty> InventoryItem::_LoadItem(uint32 itemID,
         // Station:
         ///////////////////////////////////////
         case EVEDB::invGroups::Station: {
-            return Station::_LoadItem<Station>( itemID, type, data );
+            return CelestialObject::_LoadItem<Station>( itemID, type, data );
         }
     }
 


### PR DESCRIPTION
Fixes error thrown by G++ when compiling with any optimisation level,
Error is caused by undefined reference and is only caught when optimisations are enabled.

I did not want to add this to my own bug fix branch right now, due to it using templates,
I have no experience working with templates and this might break other stuff.

Someone who understands template functions should probably verify that this does not 
cause bad things.